### PR TITLE
Fix game ending before player 2 played if random station is 1

### DIFF
--- a/src/station-race.ts
+++ b/src/station-race.ts
@@ -196,13 +196,13 @@ const turn = (state: Setup): Turn => {
 };
 
 const getOffTheTrain = (state: Turn): GameOver | TurnResult =>
-  hasWinner(state) ? gameOver(state) : turnResult(state);
+  isCurrentPlayerWinner(state) ? gameOver(state) : turnResult(state);
 
 const gameOver = (state: Turn): GameOver => ({
   ...configuration(state),
   tag: "GameOver",
 
-  winner: winner(state)!
+  winner: state.players[state.currentPlayer]!
 });
 
 const turnResult = (state: Turn): TurnResult => ({
@@ -321,10 +321,7 @@ const configuration: (state: State) => Configuration = R.pick([
   "registeredPlayers"
 ]);
 
-export const winner = (game: Game): Player | undefined =>
-  game.players.find(player => player.station === game.secretStation);
-
-export const hasWinner = (game: Game): boolean => !!winner(game);
+export const isCurrentPlayerWinner = (game: Game): boolean => game.players[game.currentPlayer].station === game.secretStation;
 
 export const hasEnoughPlayers = (config: Configuration): boolean =>
   R.values(config.registeredPlayers).filter(Boolean).length >=


### PR DESCRIPTION
The game was checking if there was any winner when a player gets off the train. So if the randomly picked station is 1, the second player would win as soon as player 1 gets off the train because the player's selected station is 1 by default.

By only checking the current player for winning conditions, we ensure this doesn't happen anymore.